### PR TITLE
Add support relative paths for partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ Configure the transformer in a `handlebars-jest` property in your Jest config's 
         "helperDirs": [
           "/some/path"
         ],
-        "partialDirs": [
-          "/some/other/path"
+        "relativePathPartials": true,
+        "partialFileExtension": ".hbs",
+        "partialDirs": [ 
+          "/some/other/path"  
         ]
       }
     }
@@ -50,3 +52,6 @@ The following options are supported:
 
 - *helperDirs*: Defines directories to be searched for helpers.
 - *partialDirs*: Defines directories to be searched for partials.
+- *relativePathPartials*: Look up partials using relative paths i.e. `{{> ../partials/customer}}` (default `true`)
+- *partialFileExtension*: Look up partials using relative paths i.e. `{{> ../partials/customer}}` (default `.hbs`)
+

--- a/__tests__/lib/create-custom-compiler-class.spec.js
+++ b/__tests__/lib/create-custom-compiler-class.spec.js
@@ -22,6 +22,7 @@ describe('CustomCompiler', function() {
     const CustomCompiler = createCustomCompilerClass({
       helperDirs: ['/some/path'],
       partialDirs: ['/other/path'],
+      relativePathPartials: true,
     });
 
     expect(new CustomCompiler()).toBeInstanceOf(Handlebars.JavaScriptCompiler);

--- a/lib/create-custom-compiler-class.js
+++ b/lib/create-custom-compiler-class.js
@@ -9,6 +9,8 @@ const getHandlebarsJestConfig = require('./get-handlebars-jest-config');
 module.exports = function createCustomCompiler() {
   const config = getHandlebarsJestConfig();
   const foundHelpers = findHelpers(config.helperDirs);
+  const relativePathPartials = !!config.relativePathPartials
+  const partialFileExtension = config.partialFileExtension || '.hbs'
   const foundPartials = findPartials(config.partialDirs);
 
   const JavaScriptCompiler = Handlebars.JavaScriptCompiler;
@@ -24,6 +26,9 @@ module.exports = function createCustomCompiler() {
     if (type === 'partial') {
       if (name === '@partial-block') {
         return JavaScriptCompiler.prototype.nameLookup.apply(this, arguments);
+      }
+      if (relativePathPartials) {
+        return 'require(' + JSON.stringify('./' + name + partialFileExtension) + ')';
       }
       if (foundPartials[name]) {
         return 'require(' + JSON.stringify(foundPartials[name]) + ')';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "handlebars-jest",
-  "version": "0.2.0",
+  "name": "jest-handlebars-loader",
+  "version": "0.0.1",
   "description": "Handlebars transformer for Jest",
   "main": "handlebars-jest.js",
   "files": [
@@ -16,21 +16,23 @@
     "jest handlebars",
     "jest handlebars transform",
     "jest handlebars preprocessor",
+    "jest handlebars loader",
     "handlebars jest",
     "handlebars jest",
     "handlebars jest transform",
-    "handlebars jest preprocessor"
+    "handlebars jest preprocessor",
+    "handlebars jest loader"
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/tylergould/handlebars-jest.git"
+    "url": "git://github.com/helpscout/handlebars-jest.git"
   },
   "author": "Tyler Gould <tg@tylergould.net>",
   "license": "MIT",
   "peerDependencies": {},
   "devDependencies": {
     "handlebars": "^4.0.11",
-    "jest": "^22.4.3",
+    "jest": "^23.6.0",
     "mock-fs": "^4.5.0"
   },
   "dependencies": {


### PR DESCRIPTION
Add default support for using relative paths for partials, i.e. `{{> ../partials/sidebar}}`